### PR TITLE
广度优先遍历 和 深度优先遍历

### DIFF
--- a/src/main/java/com/github/hcsp/algorithm/BinaryTree.java
+++ b/src/main/java/com/github/hcsp/algorithm/BinaryTree.java
@@ -1,7 +1,6 @@
 package com.github.hcsp.algorithm;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class BinaryTree {
     public static void main(String[] args) {
@@ -11,6 +10,12 @@ public class BinaryTree {
         TreeNode node4 = new TreeNode(4);
         TreeNode node5 = new TreeNode(5);
         TreeNode node6 = new TreeNode(6);
+        TreeNode node7 = new TreeNode(7);
+        TreeNode node8 = new TreeNode(8);
+        TreeNode node9 = new TreeNode(9);
+        TreeNode node10 = new TreeNode(10);
+
+
 
         node1.left = node2;
         node1.right = node3;
@@ -20,18 +25,64 @@ public class BinaryTree {
 
         node3.right = node6;
 
-        System.out.println(bfs(node1));
+        node4.left = node8;
+        node4.right = node9;
+
+        node6.left = node7;
+        node6.right = node10;
+
+//        System.out.println(bfs(node1));
         System.out.println(dfs(node1));
     }
 
     // 请实现二叉树的广度优先遍历（层次遍历）
     public static List<Integer> bfs(TreeNode root) {
-        return Collections.emptyList();
+        List<Integer> list = new ArrayList<>();
+        Queue<TreeNode> queue = new LinkedList<>();
+        queue.add(root);
+        // 使用队列存储树节点
+        while (queue.size() != 0) {
+            TreeNode tempRoot = queue.poll();
+            list.add(tempRoot.value);
+            if (tempRoot.left != null) {
+                queue.add(tempRoot.left);
+            }
+            if (tempRoot.right != null) {
+                queue.add(tempRoot.right);
+            }
+        }
+        return list;
     }
+
+
 
     // 请实现二叉树的深度优先遍历（前序）
     public static List<Integer> dfs(TreeNode root) {
-        return Collections.emptyList();
+        List<Integer> list = new ArrayList<>();
+        // 使用栈（双端队列）
+        Deque<TreeNode> deque = new LinkedList<>();
+        deque.add(root);
+        list.add(root.value);
+        boolean flag = true;
+        while (deque.size() != 0) {
+            TreeNode tempNode = deque.peekLast();
+            if (tempNode.left != null && flag) {
+                TreeNode leftNode = tempNode.left;
+                list.add(leftNode.value);
+                deque.add(leftNode);
+            } else {
+                deque.pollLast();
+                if (tempNode.right != null) {
+                    TreeNode rightNode = tempNode.right;
+                    list.add(rightNode.value);
+                    deque.add(rightNode);
+                    flag = true;
+                } else {
+                    flag = false;
+                }
+            }
+        }
+        return list;
     }
 
     public static class TreeNode {


### PR DESCRIPTION
广度优先遍历 我使用（队列先进先出的特点）去存储每一个父节点，然后出队找左右子节点

深度优先遍历 我使用栈（后进先出的特点）先去存储每一个左节点，直到这个左节点没有子左节点，然后出栈，同时用一个标志，告诉上一个节点，不用再去查左节点了，直接查右节点

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

